### PR TITLE
画面の遷移の修正

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -77,7 +77,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return "employee/list";
+		return toLogin();
 	}
 
 	/////////////////////////////////////////////////////


### PR DESCRIPTION
[what]
画面遷移の修正
[why]
「管理者登録後、従業員一覧画面に飛んでしまうので、 きちんとログイン画面を表示させて欲しい」という修正の依頼があったため。

画面の遷移の修正をおこないましたのでお手隙の際にレビューお願いいたします。